### PR TITLE
Add a button for exporting logs to the shared Documents folder

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,5 +44,6 @@ android {
 dependencies {
     implementation 'androidx.core:core:1.3.1'
     implementation 'at.favre.lib:hkdf:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.13'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:label="corona-sniffer">
         <activity
             android:name="MainActivity"
+            android:theme="@style/Theme.AppCompat"
             android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/src/sniffer/java/org/example/coronasniffer/MainActivity.java
+++ b/android/src/sniffer/java/org/example/coronasniffer/MainActivity.java
@@ -1,18 +1,30 @@
 package org.example.coronasniffer;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.content.ContentValues;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.location.Location;
+import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
+import android.os.FileUtils;
 import android.os.RemoteException;
+import android.provider.MediaStore;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.widget.TextView;
+
+import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.bosphere.filelogger.FL;
 import com.bosphere.filelogger.FLConfig;
@@ -31,9 +43,14 @@ import org.altbeacon.beacon.RangeNotifier;
 import org.altbeacon.beacon.Region;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Collection;
 
-public class MainActivity extends Activity implements BeaconConsumer {
+public class MainActivity extends AppCompatActivity implements BeaconConsumer {
     private static final String BEACON_LAYOUT
             // = "m:2-3=0215,i:4-19,i:20-21,i:22-23,p:24-24"; // iBeacon
             // = "s:0-1=feaa,m:2-2=00,p:3-3:-41,i:4-13,i:14-19";  // Eddystone UID
@@ -44,6 +61,7 @@ public class MainActivity extends Activity implements BeaconConsumer {
     private TextView countView, rssiView;
     private Region region = new Region("dummy-id", null, null, null);
     private FusedLocationProviderClient locationProvider;
+    private File privateLogDir;
 
     private RangeNotifier rangeNotifier = new RangeNotifier() {
         @SuppressLint("DefaultLocale")
@@ -79,17 +97,17 @@ public class MainActivity extends Activity implements BeaconConsumer {
         rssiView = findViewById(R.id.rssi_view);
 
         // logging
-        File logdir = new File(getExternalCacheDir(), "logs");
+        privateLogDir = new File(getExternalCacheDir(), "logs");
         FL.init(new FLConfig.Builder(this)
                 //.minLevel(FLConst.Level.V)
                 .minLevel(FLConst.Level.D)
                 .logToFile(true)
-                .dir(logdir)
+                .dir(privateLogDir)
                 .defaultTag(MainActivity.class.getSimpleName())
                 .retentionPolicy(FLConst.RetentionPolicy.NONE)
                 .build());
         FL.setEnabled(true);
-        FL.d("logging to " + logdir.getAbsolutePath());
+        FL.d("logging to " + privateLogDir.getAbsolutePath());
 
         locationProvider = LocationServices.getFusedLocationProviderClient(this);
     }
@@ -104,6 +122,47 @@ public class MainActivity extends Activity implements BeaconConsumer {
         }
 
         ensureScanning();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.options_menu, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                switch (which){
+                    case DialogInterface.BUTTON_POSITIVE:
+                        AsyncTask.execute(new Runnable() {
+                            @Override
+                            public void run() {
+                                exportLogs();
+                            }
+                        });
+                        break;
+                    case DialogInterface.BUTTON_NEGATIVE:
+                        break;
+                }
+            }
+        };
+
+        switch (item.getItemId()) {
+            case R.id.export_logs:
+                AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                builder.setMessage(
+                        "This will copy the sensitive logs to the Documents folder, " +
+                        "which is accessible to all other apps too. Deleting them as soon " +
+                        "as not needed anymore is highly recommended.")
+                        .setPositiveButton("Do it!", dialogClickListener)
+                        .setNegativeButton("Cancel", dialogClickListener).show();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 
     private void ensureScanning() {
@@ -205,5 +264,29 @@ public class MainActivity extends Activity implements BeaconConsumer {
             builder.setChannelId(channel.getId());
         }
         return builder.build();
+    }
+
+    // Note: if not running Android Q+, you probably don't need this and can just copy files using ADB
+    @RequiresApi(api = Build.VERSION_CODES.Q)
+    private void exportLogs() {
+        String storePath = Environment.DIRECTORY_DOCUMENTS + "/" + getPackageName() + "/logs";
+        FL.d("exporting files to " + storePath);
+        for (File f : privateLogDir.listFiles()) {
+            FL.d("exporting " + f.getAbsolutePath());
+            ContentValues cv = new ContentValues();
+            cv.put(MediaStore.MediaColumns.DISPLAY_NAME, f.getName());
+            cv.put(MediaStore.MediaColumns.MIME_TYPE, "text/plain");
+            cv.put(MediaStore.MediaColumns.RELATIVE_PATH, storePath);
+            cv.put(MediaStore.MediaColumns.DATA, f.getAbsolutePath());
+            Uri uri = getContentResolver().insert(MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL), cv);
+            try (
+                OutputStream outStream = getContentResolver().openOutputStream(uri, "w");
+                InputStream inputStream = new FileInputStream(f))
+            {
+                FileUtils.copy(inputStream, outStream);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/android/src/sniffer/res/menu/options_menu.xml
+++ b/android/src/sniffer/res/menu/options_menu.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:id="@+id/export_logs" android:title="Export logs" />
+</menu>


### PR DESCRIPTION
This may be needed on Android Q+ or in other cases when ADB cannot
be used to read the private cache folder.